### PR TITLE
chore: remove "Book a demo" CTA from microsite

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -194,15 +194,6 @@ export default function App() {
           <span style={{ display: "flex", alignItems: "center", gap: 14 }}>
             <LiveBadge>Updated daily</LiveBadge>
             <GitHubButton repo="kadoa-org/quant-job-market" />
-            <a
-              className="dk-btn dk-btn--brand"
-              href="https://www.kadoa.com/contact"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ textDecoration: "none" }}
-            >
-              Book a demo
-            </a>
           </span>
         }
       />

--- a/src/kit/index.jsx
+++ b/src/kit/index.jsx
@@ -170,13 +170,6 @@ export function SiteFooter({ current }) {
         </nav>
         <div className="dk-footer-cta">
           <a href="https://www.kadoa.com">What is Kadoa?</a>
-          <a
-            className="dk-btn dk-btn--brand dk-btn--sm"
-            href="https://www.kadoa.com/contact"
-            style={{ textDecoration: "none" }}
-          >
-            Book a demo
-          </a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Removes the "Book a demo" CTA from both the header and the cross-dataset footer, per request. Header keeps freshness/GitHub/search; footer keeps the sibling-dataset links + "What is Kadoa?". Build-verified (no residual CTA in output).