### PR TITLE
Revert to gov.uk design system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -178,12 +178,7 @@ export default function App() {
   return (
     <div className="min-h-screen sm:h-screen w-screen flex flex-col">
       <SiteHeader
-        brand={
-          <span className="dk-brand-lockup">
-            <img src={`${import.meta.env.BASE_URL}kadoa-icon.svg`} alt="Kadoa" width="18" height="18" />
-            Quant Job Market
-          </span>
-        }
+        brand="📊 Quant Job Market"
         LinkComponent={(p) => <a {...p} />}
         brandSuffix={
           <a href="https://www.kadoa.com" target="_blank" rel="noreferrer" className="dk-header-link">

--- a/src/kit/kit.css
+++ b/src/kit/kit.css
@@ -24,10 +24,6 @@
   --dk-green: #0f7a52;
   --dk-red: #ca3535;
   --dk-focus: #ffdd00;
-  /* Kadoa brand — accent + header ink (see kadoa-icon.svg, www.kadoa.com) */
-  --dk-brand: #fd7412;
-  --dk-brand-hover: #e2680f;
-  --dk-brand-ink: #18181b;
   /* spacing */
   --dk-cell-y: 7px;
   --dk-cell-x: 10px;
@@ -81,25 +77,17 @@
 /* ── SiteHeader + NavBar ── */
 .dk-container { max-width: 960px; margin: 0 auto; padding: 0 15px; }
 @media (min-width: 40.0625em) { .dk-container { padding: 0 30px; } }
-.dk-header { background: var(--dk-brand-ink); color: #fff; }
-.dk-brand-lockup { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
-.dk-brand-lockup img { flex-shrink: 0; display: block; }
-/* .dk-btn.dk-btn--brand: two-class specificity so the orange background beats
-   the base .dk-btn (white bg, defined later) and .dk-footer a (white text).
-   Dark ink text on orange = 6.6:1 (WCAG AA); white-on-orange was ~2.8:1. */
-.dk-btn.dk-btn--brand { background: var(--dk-brand); border-color: var(--dk-brand); color: var(--dk-brand-ink); }
-.dk-btn.dk-btn--brand:hover { background: var(--dk-brand-hover); border-color: var(--dk-brand-hover); color: var(--dk-brand-ink); }
-.dk-btn--sm { padding: 5px 11px; font-size: var(--dk-fs-s); }
-/* Cross-dataset footer (brand ink + orange rule, mirrors the header) */
-.dk-footer { border-top: 3px solid var(--dk-brand); background: var(--dk-brand-ink); color: rgba(255,255,255,0.82); }
-.dk-footer-inner { display: flex; align-items: center; justify-content: space-between; gap: 10px 20px; flex-wrap: wrap; padding: 14px 0; font-size: var(--dk-fs-s); }
+.dk-header { background: var(--dk-link); color: #fff; }
+/* Cross-dataset footer — gov.uk style: light surface, hairline rule, blue links */
+.dk-footer { border-top: 1px solid var(--dk-rule); background: var(--dk-bg); color: var(--dk-muted); }
+.dk-footer-inner { display: flex; align-items: center; justify-content: space-between; gap: 10px 20px; flex-wrap: wrap; padding: 20px 0; font-size: var(--dk-fs-s); }
 .dk-footer-nav { display: inline-flex; align-items: center; gap: 8px 16px; flex-wrap: wrap; }
-.dk-footer-label { color: rgba(255,255,255,0.55); }
-.dk-footer a { color: #fff; text-decoration: none; }
-.dk-footer a:hover { text-decoration: underline; text-underline-offset: 3px; }
-.dk-footer-here { color: var(--dk-brand); font-weight: 600; }
+.dk-footer-label { color: var(--dk-muted); }
+.dk-footer a { color: var(--dk-link); text-decoration: underline; text-underline-offset: 3px; }
+.dk-footer a:hover { text-decoration: none; }
+.dk-footer-here { color: var(--dk-ink); font-weight: 600; }
 .dk-footer-cta { display: inline-flex; align-items: center; gap: 16px; }
-.dk-footer a:focus-visible, .dk-footer .dk-btn:focus-visible { outline: 3px solid var(--dk-focus); outline-offset: 2px; }
+.dk-footer a:focus-visible { outline: 3px solid var(--dk-focus); outline-offset: 2px; }
 .dk-header-inner { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding-top: 10px; padding-bottom: 10px; flex-wrap: wrap; row-gap: 8px; }
 /* min-width:0 + ellipsis so a long brand truncates instead of forcing the
    page wider than the viewport (mobile header-overflow bug). flex-wrap on the


### PR DESCRIPTION
Matches the congress revert (kadoa-org/congress-trading-monitor#5).

- Header back to gov.uk blue (was near-black brand ink)
- Cross-dataset footer restyled from dark/orange to gov.uk (light, hairline rule, blue links)
- Dropped orange brand tokens, `.dk-btn--brand/--sm`, header Kadoa-icon lockup
- Brand back to plain emoji ("📊 Quant Job Market")
- Demo button already removed (PR #7)

Shared kit (`src/kit/kit.css`) is byte-identical across congress/quant/layoffs. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)