### PR TITLE
SEO: link footer label (Open data → /datasets, Kadoa → home)

### DIFF
--- a/scripts/prerenderSeo.mjs
+++ b/scripts/prerenderSeo.mjs
@@ -129,7 +129,7 @@ const siteHeader = `<header class="dk-header">
 const siteFooter = `<footer class="dk-footer">
   <div class="dk-container dk-footer-inner">
     <nav class="dk-footer-nav" aria-label="Kadoa open datasets">
-      <span class="dk-footer-label">Open data by Kadoa</span>
+      <span class="dk-footer-label"><a href="https://www.kadoa.com/datasets">Open data</a> by <a href="https://www.kadoa.com/">Kadoa</a></span>
       <span class="dk-footer-here" aria-current="page">Quant Jobs</span>
       <a href="https://www.kadoa.com/layoffs/">Layoffs Tracker</a>
       <a href="https://www.kadoa.com/congress/">Congress Trades</a>

--- a/scripts/prerenderSeo.mjs
+++ b/scripts/prerenderSeo.mjs
@@ -131,9 +131,9 @@ const siteFooter = `<footer class="dk-footer">
     <nav class="dk-footer-nav" aria-label="Kadoa open datasets">
       <span class="dk-footer-label"><a href="https://www.kadoa.com/datasets">Open data</a> by <a href="https://www.kadoa.com/">Kadoa</a></span>
       <span class="dk-footer-here" aria-current="page">Quant Jobs</span>
-      <a href="https://www.kadoa.com/layoffs/">Layoffs Tracker</a>
-      <a href="https://www.kadoa.com/congress/">Congress Trades</a>
-      <a href="https://www.kadoa.com/potus/">POTUS Tracker</a>
+      <a href="https://www.kadoa.com/layoffs">Layoffs Tracker</a>
+      <a href="https://www.kadoa.com/congress">Congress Trades</a>
+      <a href="https://www.kadoa.com/potus">POTUS Tracker</a>
     </nav>
   </div>
 </footer>`;


### PR DESCRIPTION
Links the footer's "Open data by Kadoa" label: **"Open data" → /datasets**, **"Kadoa" → the site home** — consistent with the POTUS cross-dataset footer. Open-data hub + attribution only; no promotional links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)